### PR TITLE
Feat: submission flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ Set the `POPCORN_API_URL` environment variable to the URL of the Popcorn API. Yo
 
 ## Make your first submission
 
-After this, you can submit a solution by running:
+```bash
+wget https://raw.githubusercontent.com/gpu-mode/reference-kernels/refs/heads/main/problems/pmpp/grayscale_py/submission.py
+popcorn-cli submit --gpu A100 --leaderboard grayscale --mode leaderboard submission.py
+```
+
+## Discover new problems
+
+The CLI supports (almost) everything Discord does, so you can also discovery which leaderboards are available. To make discovery more pleasant we also offer a CLI experience.
 
 ```bash
 popcorn-cli submit <submission-file>


### PR DESCRIPTION
An initial implementation for #10 regarding flags for submission


Example Usage:

This PR introduces command-line flags to streamline the submission process for users iterating on a specific problem.

Direct Submission (All Flags):
If you know the GPU, leaderboard, and desired mode, you can skip the interactive UI:

## Explicitly specifying mode:
`./target/release/popcorn-cli --gpu MI300 --leaderboard amd-fp8-mm --mode leaderboard path/to/your/submission.py`
Expected Behavior: The TUI screen will appear immediately showing "Submitting solution...". No interactive selection is needed. Upon completion, the final status is displayed, and the program exits.

## Partial Flags (Interactive Fallback):
If you only provide some flags, the interactive UI will appear, pre-selecting the provided options and prompting for the missing ones:

## Only GPU provided
`./target/release/popcorn-cli --gpu MI300 path/to/your/submission.py`
Expected Behavior: The TUI screen appears. It skips the GPU selection (as "MI300" is implicitly selected) and directly shows the "Select Leaderboard" list. After selecting a leaderboard and submission mode, the submission proceeds.

No Flags (Original Behavior):
Running without flags keeps the original interactive experience:

`./target/release/popcorn-cli path/to/your/submission.py`
Expected Behavior: The TUI screen appears, starting with the "Select Leaderboard" list, followed by GPU and submission mode selection.

Note: both the implicit submit and the `submit` option have the same behavior








