### PR TITLE
Extend submit solution timeout to 1 hour

### DIFF
--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -126,7 +126,7 @@ pub async fn submit_solution<P: AsRef<Path>>(
     let resp = client
         .post(&url)
         .multipart(form)
-        .timeout(Duration::from_secs(300))
+        .timeout(Duration::from_secs(3600))
         .send()
         .await?;
 


### PR DESCRIPTION
Right now we're running into the problem where the cli is timing out before the timeout which is defined in https://github.com/gpu-mode/reference-kernels. 

Reference Kernels should be the source of truth so on the cli we just need the timeout to be long enough to accommodate for everything + exist. I think extending things for 1 hour should accomplish this.

Testing:
`./target/release/popcorn-cli submit --gpu MI300 --leaderboard amd-mixture-of-experts --mode leaderboard submission.py` timed out before the change but not after the change. The submission is the one here https://github.com/gpu-mode/reference-kernels/blob/main/problems/amd/moe/submission.py