### PR TITLE
[codex] document submission inspection and deletion flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,22 +124,22 @@ popcorn submissions delete <ID>
 popcorn submissions delete <ID> --force
 ```
 
-Smallest possible flow:
+#### Avoid Reward Hacks
+
+If you want to avoid reward hacks, inspect your past submissions and delete any bad ones.
 
 ```bash
 # 1. List your submissions and note the ID
 popcorn submissions list --leaderboard grayscale_v2
 
-# 2. Inspect the stored code for that submission ID
+# 2. Inspect the exact code stored for that submission
 popcorn submissions show 1234
 
-# 3. Delete that submission ID
+# 3. Delete the submission if you do not want it kept
 popcorn submissions delete 1234
 ```
 
-`list` shows the submission `ID`, `show` prints the full submitted code for that `ID`, and `delete` previews the submission and asks for confirmation before removing it.
-
-If you have a reward-hacked or otherwise bad submission, you can use this flow to find the submission ID, inspect the exact code that was stored, and delete it yourself.
+`list` shows the submission `ID`, `show` prints the full submitted code for that `ID`, and `delete` previews the submission before removing it.
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ popcorn submissions delete <ID>
 popcorn submissions delete <ID> --force
 ```
 
+Smallest possible flow:
+
+```bash
+# 1. List your submissions and note the ID
+popcorn submissions list --leaderboard grayscale_v2
+
+# 2. Inspect the stored code for that submission ID
+popcorn submissions show 1234
+
+# 3. Delete that submission ID
+popcorn submissions delete 1234
+```
+
+`list` shows the submission `ID`, `show` prints the full submitted code for that `ID`, and `delete` previews the submission and asks for confirmation before removing it.
+
+If you have a reward-hacked or otherwise bad submission, you can use this flow to find the submission ID, inspect the exact code that was stored, and delete it yourself.
+
 ### Authentication
 
 Register or re-register your CLI with Discord or GitHub.


### PR DESCRIPTION
## What changed
Adds a short README note showing the minimal `popcorn submissions list/show/delete` flow so users can inspect and remove a bad or reward-hacked submission themselves.

## Why
Users need an obvious place in the main CLI docs that explains they can:
- list submissions to find the submission ID
- inspect the stored code for that ID
- delete that submission if needed

## User impact
People using `popcorn-cli` can recover from an accidental or reward-hacked submission without asking for manual intervention.

## Validation
- Verified the commands against the live service using `grayscale_v2`
- Confirmed `list` returned a real submission ID
- Confirmed `show` printed the stored code for that ID
- Confirmed `delete --force` removed that submission
- No code changes or automated tests were needed for this README-only update