### PR TITLE
[codex] add arm64 smoke test workflow

### DIFF
--- a/.github/workflows/arm64-smoke.yml
+++ b/.github/workflows/arm64-smoke.yml
@@ -1,0 +1,51 @@
+name: ARM64 Smoke Test
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".cargo/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "build.rs"
+      - "install.sh"
+      - "src/**"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  arm64-linux:
+    name: Native ARM64 Linux Smoke Test
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ubuntu-24.04-arm-smoke
+
+      - name: Build ARM64 binary
+        run: cargo build --release
+
+      - name: Package expected release asset
+        run: |
+          mkdir -p dist
+          cp target/release/popcorn-cli dist/popcorn-cli
+          chmod +x dist/popcorn-cli
+          tar -czf popcorn-cli-linux-aarch64.tar.gz -C dist popcorn-cli
+
+      - name: Verify packaged binary runs
+        run: |
+          mkdir -p smoke
+          tar -xzf popcorn-cli-linux-aarch64.tar.gz -C smoke
+          ./smoke/popcorn-cli --version


### PR DESCRIPTION
## Summary

- add a standalone GitHub Actions workflow that runs on `ubuntu-24.04-arm`
- build the CLI natively on ARM64 Linux
- package the expected `popcorn-cli-linux-aarch64.tar.gz` artifact and smoke-test `popcorn-cli --version`

## Why

This provides a free, native ARM64 validation path in GitHub Actions without changing the release pipeline yet. It lets us test ARM Linux support before deciding whether to merge and publish the separate ARM64 release artifact work.

## Validation

- parsed the workflow YAML locally
- this PR should exercise the GitHub-hosted ARM64 runner in CI
