### PR TITLE
Update QR guide for qr_v2

### DIFF
--- a/docs/linalg-qr-b200.md
+++ b/docs/linalg-qr-b200.md
@@ -10,19 +10,19 @@ popcorn register discord
 Get the starter B200 QR submission:
 
 ```bash
-curl -O https://raw.githubusercontent.com/gpu-mode/reference-kernels/main/problems/linalg/qr_py/submission.py
+curl -O https://raw.githubusercontent.com/gpu-mode/reference-kernels/main/problems/linalg/qr_v2/submission.py
 ```
 
 Run a correctness test:
 
 ```bash
-popcorn submit --leaderboard qr --gpu B200 --mode test submission.py
+popcorn submit --leaderboard qr_v2 --gpu B200 --mode test submission.py
 ```
 
 Submit to the leaderboard:
 
 ```bash
-popcorn submit --leaderboard qr --gpu B200 --mode leaderboard submission.py
+popcorn submit --leaderboard qr_v2 --gpu B200 --mode leaderboard submission.py
 ```
 
 Questions: ask in the `linalg` channel on [discord.gg/gpumode](https://discord.gg/gpumode).


### PR DESCRIPTION
## Summary
- update the B200 QR guide to download the `qr_v2` starter submission
- point test and leaderboard submit examples at `qr_v2`

## Validation
- checked the rendered markdown source locally
