### PR TITLE
Document versioned release installs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,16 @@ jobs:
         with:
           tag_name: ${{ needs.version.outputs.new_tag }}
           name: Release ${{ needs.version.outputs.new_tag }}
+          body: |
+            Download the archive for your platform:
+
+            - Linux x86_64: `popcorn-cli-linux.tar.gz`
+            - Linux aarch64: `popcorn-cli-linux-aarch64.tar.gz`
+            - macOS Apple Silicon: `popcorn-cli-macos.tar.gz`
+            - Windows x86_64: `popcorn-cli-windows.zip`
+
+            Extract the archive, move `popcorn-cli` into a directory on your `PATH`,
+            and run `popcorn --version` to confirm the installed version.
           files: |
             popcorn-cli-linux.tar.gz/popcorn-cli-linux.tar.gz
             popcorn-cli-linux-aarch64.tar.gz/popcorn-cli-linux-aarch64.tar.gz

--- a/README.md
+++ b/README.md
@@ -31,10 +31,18 @@ After installation, restart your terminal (or run `source ~/.bashrc` / `source ~
 
 ### Option 2: Manual Installation
 
-1. Download the binary for your OS from [releases](https://github.com/gpu-mode/popcorn-cli/releases/latest)
-2. Extract the archive
-3. Move the binary to a directory in your PATH
-4. Make it executable (Linux/macOS): `chmod +x popcorn-cli`
+1. Open the [releases page](https://github.com/gpu-mode/popcorn-cli/releases)
+2. Pick the version you want, or use the latest release
+3. Download the archive for your platform:
+   - Linux x86_64: `popcorn-cli-linux.tar.gz`
+   - Linux aarch64: `popcorn-cli-linux-aarch64.tar.gz`
+   - macOS Apple Silicon: `popcorn-cli-macos.tar.gz`
+   - Windows x86_64: `popcorn-cli-windows.zip`
+4. Extract the archive, move `popcorn-cli` into a directory on your `PATH`,
+   and run `popcorn --version` to confirm the installed version.
+
+Older versions are available from the same Releases page by selecting a previous
+tag.
 
 ### Option 3: Building from source
 


### PR DESCRIPTION
## Summary\n- point manual installation at the versioned GitHub releases page\n- add release-body install guidance mapping each platform to the right archive\n- update the current GitHub release page for v1.3.17 with the same platform-specific asset guidance\n- avoid calling out any specific release as good or bad\n\n## Testing\n- cargo test --locked